### PR TITLE
open issue #8 UISlider snap functionality and tick marks

### DIFF
--- a/SpotifyRadar_iOS/App/Dashboard/Recently Played/RecentlyPlayedTracksViewModel.swift
+++ b/SpotifyRadar_iOS/App/Dashboard/Recently Played/RecentlyPlayedTracksViewModel.swift
@@ -65,7 +65,7 @@ RecentlyPlayedTracksViewModelOutput {
         self.dataManager = dataManager
         self.safariService = safariService
         
-        // Initializing utputs
+        // Initializing outputs
         title = Observable.just("Your Recently Played Tracks")
         
         trackCollections = sessionService.getRecentlyPlayedTracks(limit: 50)


### PR DESCRIPTION
added tick marks to the newReleasesSlider UISlider and snap functionality as detailed in issue 8. also fixed a typo.

Fixes #
created 12 custom views to be placed on the UISlider so users can know when to release the thumb. also added snap functionality to the UISlider that rounds too nearest whole number
